### PR TITLE
Fix LOST_OVERDUE enum typo

### DIFF
--- a/Server/src/main/java/com/library/Model/Enum/Reason.java
+++ b/Server/src/main/java/com/library/Model/Enum/Reason.java
@@ -4,7 +4,7 @@ public enum Reason {
     DAMAGED_MINOR("Sách hỏng nhẹ"),
     DAMAGED_MAJOR("Sách hỏng nặng"),
     LOST("Mất sách"),
-    LOST_OVEVERDUE("Mất do quá hạn trả sách"),
+    LOST_OVERDUE("Mất do quá hạn trả sách"),
     LATE_RETURN("Trễ hạn trả sách"),
     LATE_FINE_PAYMENT("Trễ hạn nộp phạt");
 

--- a/Server/src/main/java/com/library/Service/BorrowRecordService.java
+++ b/Server/src/main/java/com/library/Service/BorrowRecordService.java
@@ -249,7 +249,7 @@ public class BorrowRecordService {
                         fineRecord.setBook(book);
                         fineRecord.setDueDate(null);
                         fineRecord.setStatus(FineRecordStatus.PENDING);
-                        fineRecord.setFineReason(Reason.LOST_OVEVERDUE);
+                        fineRecord.setFineReason(Reason.LOST_OVERDUE);
                         fineRecordService.saveOrUpdateFineRecord(fineRecord);
                         historyRecordService.saveHistory(borrowedRecord, "Tạo đơn phạt với lý do sách bị mất vì quá hạn trả", "Hệ thống");
                     }

--- a/Server/src/main/java/com/library/Service/FineRecordService.java
+++ b/Server/src/main/java/com/library/Service/FineRecordService.java
@@ -67,7 +67,7 @@ public class FineRecordService {
             return fineRecordRepository.save(fineRecord);
         } else{
             switch (fineRecord.getFineReason()) {
-                case LOST, LOST_OVEVERDUE -> {
+                case LOST, LOST_OVERDUE -> {
                     fineRecord.setFineAmount(fineRecord.getBook().getPrice() * 2);
                     copyService.updateStatusCopy(fineRecord.getBook(), CopyStatus.BORROWED, CopyStatus.LOST);
                 }
@@ -91,7 +91,7 @@ public class FineRecordService {
             }
             if (fineRecord.getStatus().equals(FineRecordStatus.PENDING)) {
                 fineRecord.setFineDate(Date.valueOf(LocalDate.now()));
-                fineRecord.setDueDate(fineRecord.getFineReason().equals(Reason.LOST_OVEVERDUE)
+                fineRecord.setDueDate(fineRecord.getFineReason().equals(Reason.LOST_OVERDUE)
                         ?  Date.valueOf(LocalDate.now())
                         :  Date.valueOf(LocalDate.now().plusDays(7)));
             }


### PR DESCRIPTION
## Summary
- fix typo in `Reason` enum constant `LOST_OVERDUE`
- update usages in service classes

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858d2c7fe408330819be8e24d404a91